### PR TITLE
Ensure each item in a queue is processed

### DIFF
--- a/gonotego/command_center/runner.py
+++ b/gonotego/command_center/runner.py
@@ -28,7 +28,11 @@ def main():
   scheduler.executor_singleton = executor
   while True:
     while command_events_queue.size() > 0:
+      # We commit the item before executing the command.
+      # So, if the command fails, it will not be re-executed.
       command_event_bytes = command_events_queue.get()
+      command_events_queue.commit(command_event_bytes)
+
       command_event = events.CommandEvent.from_bytes(command_event_bytes)
       command_text = command_event.command_text
       executor.execute(command_text)

--- a/gonotego/common/interprocess.py
+++ b/gonotego/common/interprocess.py
@@ -10,12 +10,38 @@ class InterprocessQueue:
   def __init__(self, key):
     self.key = key
     self.r = get_redis_client()
+    self.index = 0
 
   def put(self, value):
     return self.r.rpush(self.key, value)
 
   def get(self):
-    return self.r.lpop(self.key)
+    """Gets the next item in the queue. Does not remove it from the queue."""
+    value = self.r.lindex(self.key, self.index)
+    self.index += 1
+    return value
+
+  def commit(self, value):
+    """Removes the next item in the queue, asserting it matches the provided value.
+
+    To ensure each item is processed, use the following pattern.
+    1. value = queue.get()
+    2. process(value)
+    3. queue.commit(value)
+
+    This can still result in an item being processed or partially processed multiple times,
+    but importantly it guarantees each item is processed.
+
+    Args:
+      value: The expected value for the leftmost item in the queue.
+    """
+    if value is None:
+      return
+
+    pop_value = self.r.lpop(self.key)
+    self.index -= 1
+    assert self.index >= 0
+    assert value == pop_value
 
   def size(self):
     return self.r.llen(self.key)

--- a/gonotego/leds/runner.py
+++ b/gonotego/leds/runner.py
@@ -31,6 +31,8 @@ def main():
         dots[i] = colors[i]
       dots.show()
       time.sleep(0.005)
+
+      led_events_queue.commit(led_event_bytes)
     time.sleep(0.05)
 
 

--- a/gonotego/transcription/runner.py
+++ b/gonotego/transcription/runner.py
@@ -48,6 +48,7 @@ def main():
 
         leds.off(1)
         status.set(Status.TRANSCRIPTION_ACTIVE, False)
+    audio_events_queue.commit(audio_event_bytes)
 
     time.sleep(3)
 

--- a/gonotego/uploader/runner.py
+++ b/gonotego/uploader/runner.py
@@ -43,10 +43,12 @@ def main():
     # Don't even try uploading notes if we don't have a connection.
     internet.wait_for_internet(on_disconnect=uploader.handle_disconnect)
 
+    note_event_bytes_list = []
     note_events = []
     while note_events_queue.size() > 0:
       print('Note event received')
       note_event_bytes = note_events_queue.get()
+      note_event_bytes_list.append(note_event_bytes)
       note_event = events.NoteEvent.from_bytes(note_event_bytes)
       note_events.append(note_event)
 
@@ -58,6 +60,9 @@ def main():
       print('Uploaded.')
       leds.off(2)
       status.set(Status.UPLOADER_ACTIVE, False)
+
+    for note_event_bytes in note_event_bytes_list:
+      note_events_queue.commit(note_event_bytes)
 
     if last_upload and time.time() - last_upload > 600:
       # X minutes have passed since the last upload.


### PR DESCRIPTION
Ensures each item in a queue is processed before the item is removed from the queue.
This will prevent notes from being lost even if the transcription or uploading process fails midway.
