### PR TITLE
Add character substitution support in shell so Pi types hyphens instead of unicode minus.

### DIFF
--- a/gonotego/text/shell.py
+++ b/gonotego/text/shell.py
@@ -8,6 +8,9 @@ from gonotego.settings import secure_settings
 
 Status = status.Status
 
+MINUS = chr(8722)
+assert MINUS == '−'  # This is a unicode minus sign, not an ordinary hyphen.
+
 shift_characters = {
     '1': '!',
     '2': '@',
@@ -19,8 +22,8 @@ shift_characters = {
     '8': '*',
     '9': '(',
     '0': ')',
-    '-': '_',  # Ordinary minus sign. ord(x) == 45.
-    '−': '_',  # The kind typed on the Raspberry Pi. ord(x) == 8722.
+    '-': '_',  # Ordinary hyphen. ord(x) == 45.
+    MINUS: '_',  # The kind typed on the Raspberry Pi. ord(x) == 8722.
     '=': '+',
     '[': '{',
     ']': '}',
@@ -34,7 +37,7 @@ shift_characters = {
 }
 
 character_substitutions = {
-    '−': '-',  # The kind typed on the Raspberry Pi. ord(x) == 8722.
+    MINUS: '-',  # Replace unicode minus with ordinary hyphens.
 }
 
 

--- a/gonotego/text/shell.py
+++ b/gonotego/text/shell.py
@@ -33,6 +33,10 @@ shift_characters = {
     '/': '?',
 }
 
+character_substitutions = {
+    '−': '-',  # The kind typed on the Raspberry Pi. ord(x) == 8722.
+}
+
 
 def get_timestamp():
   return time.time()
@@ -110,6 +114,8 @@ class Shell:
       self.text += ' '
     elif len(event.name) == 1:
       character = event.name
+      if character in character_substitutions:
+        character = character_substitutions[character]
       if keyboard.is_pressed('shift') or keyboard.is_pressed('right shift'):
         character = shift_characters.get(character, character.upper())
       self.text += character


### PR DESCRIPTION
The Raspberry Pis type a non-standard hyphen. I don't want this hyphen polluting my notes. I'd like a normal hyphen thank-you-very-much.

ord(regular-hyphen) == 45
ord(pi-hyphen) == 8722

45 is the unicode hyphen-minus. https://www.codetable.net/decimal/45
8722 is the unicode minus sign. https://www.codetable.net/decimal/8722
