### PR TITLE
Add Dependabot configuration for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Added Dependabot configuration for Python dependencies with monthly update schedule
- Limited open pull requests to 10 at a time

## Test plan
- Dependabot should automatically create PRs for Python dependency updates on a monthly schedule

🤖 Generated with [Claude Code](https://claude.ai/code)