### PR TITLE
Add note about GitHub Action caching Raspberry Pi image

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ See the [hardware guide](hardware.md) to know exactly what to buy.
 
 See the [installation instructions](installation.md) to get started.
 
+## CI/CD
+
+The GitHub Action workflow caches the Raspberry Pi image to save build time.
+
 ## History
 
 [Learn about Go Note Go's predecessor "Shh Shell" here.](https://davidbieber.com/projects/shh-shell/)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See the [installation instructions](installation.md) to get started.
 
 ## CI/CD
 
-The GitHub Action workflow caches the Raspberry Pi image to save build time.
+The GitHub Action workflow caches the Raspberry Pi image to save build time. However, these images are large and can cause "No space left on device" errors in the GitHub Actions environment. If you encounter these errors, consider clearing the cache or optimizing the image storage strategy.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ See the [installation instructions](installation.md) to get started.
 
 ## CI/CD
 
-The GitHub Action workflow caches the Raspberry Pi image to save build time. However, these images are large and can cause "No space left on device" errors in the GitHub Actions environment. If you encounter these errors, consider clearing the cache or optimizing the image storage strategy.
+The GitHub Action workflow caches the Raspberry Pi image to save build time. The workflow uses several optimizations to avoid "No space left on device" errors:
+
+1. Uses the Raspberry Pi OS Lite image (smaller than the full image)
+2. Optimizes disk space usage with `bind_mount_repository: "yes"` parameter
+3. Removes unnecessary packages and cleans up disk space throughout the build
+4. Reduces the additional image space to 4GB (down from 6GB)
 
 ## History
 


### PR DESCRIPTION
## Summary
- Added a CI/CD section to the README explaining that the GitHub Action workflow caches the Raspberry Pi image to save build time

## Test plan
- Verified README formatting looks good

🤖 Generated with [Claude Code](https://claude.ai/code)