### PR TITLE
Fix build_image space issue by increasing image size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
           bootpartition: 1
           rootpartition: 2
           image_additional_mb: 6000
+          bind_mount_repository: yes
           extra_files_path: /home/runner/work/GoNoteGo/GoNoteGo/web-app-dist
           extra_files_mnt_path: web-app-dist
           commands: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,14 +62,13 @@ jobs:
             exit 1
           fi
 
-      - uses: dbieber/arm-runner-action@v1.0.8
+      - uses: dbieber/arm-runner-action@v1.0.9
         id: build_image
         with:
           base_image: https://downloads.raspberrypi.com/raspios_armhf/images/raspios_armhf-2024-03-15/2024-03-15-raspios-bookworm-armhf.img.xz
           bootpartition: 1
           rootpartition: 2
           image_additional_mb: 6000
-          bind_mount_repository: yes
           extra_files_path: /home/runner/work/GoNoteGo/GoNoteGo/web-app-dist
           extra_files_mnt_path: web-app-dist
           commands: |


### PR DESCRIPTION
## Summary
- The build_image workflow was failing because the Raspberry Pi OS image didn't have enough space when copying files
- Because the cached image was getting copied into the image, oops!

## Test plan
- The GitHub Actions workflow should complete successfully without disk space errors

🤖 Generated with [Claude Code](https://claude.ai/code)