### PR TITLE
Update build workflow to use Node.js 18.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,9 +78,13 @@ jobs:
             # Clean up apt cache to free up space
             sudo apt-get clean
 
+            echo "Installing Node.js 18.x"
+            curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+            sudo apt install -y nodejs
+
             echo "Installing dependencies!"
             sudo apt install -y git firefox-esr xvfb portaudio19-dev libatlas-base-dev redis-server espeak \
-                rustc python3-dev libopenblas-dev iptables iptables-persistent nodejs npm
+                rustc python3-dev libopenblas-dev iptables iptables-persistent
                 
             # Clean up after installation
             sudo apt-get clean


### PR DESCRIPTION
## Summary
- Update build workflow to install Node.js 18.x using the NodeSource repository
- Use the commands `curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -` and `sudo apt install -y nodejs` for the installation
- Remove nodejs and npm from apt install list as they're now installed separately

## Test plan
- The image build workflow should successfully install Node.js 18.x
- All Node.js functionality in the project should continue to work as expected

when building the image, use "curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -" and "sudo apt install -y nodejs" to install node/npm

🤖 Generated with [Claude Code](https://claude.ai/code)