### PR TITLE
Update supervisord settings-server command to use npm run dev

### DIFF
--- a/gonotego/supervisord.conf
+++ b/gonotego/supervisord.conf
@@ -50,6 +50,6 @@ directory=/home/pi
 user=pi
 
 [program:GoNoteGo-settings-server]
-command=/home/pi/code/github/dbieber/GoNoteGo/env/bin/python -m http.server 8000 --directory /home/pi/code/github/dbieber/GoNoteGo/gonotego/settings-server/dist
-directory=/home/pi/code/github/dbieber/GoNoteGo/gonotego/settings-server/dist
+command=/usr/bin/npm run dev
+directory=/home/pi/code/github/dbieber/GoNoteGo/gonotego/settings-server
 user=pi


### PR DESCRIPTION
## Summary
- Update the supervisord configuration to run the settings-server using 'npm run dev' instead of Python's http.server

## Task
update the supervisord files command for settings server to run the settings-server

🤖 Generated with [Claude Code](https://claude.ai/code)