### PR TITLE
Fix case sensitivity issues with NOTE_TAKING_SYSTEM setting

### DIFF
--- a/gonotego/command_center/system_commands.py
+++ b/gonotego/command_center/system_commands.py
@@ -22,20 +22,25 @@ SAY_COMMAND = 'say' if platform.system() == 'Darwin' else 'espeak'
 @register_command('who am i')
 def whoami():
   note_taking_system = settings.get('NOTE_TAKING_SYSTEM')
-  if note_taking_system == 'email':
+  # Normalize the system name for consistent handling
+  normalized_system = note_taking_system.lower()
+  
+  if normalized_system == 'email':
     user = settings.get('EMAIL')
-  elif note_taking_system == 'ideaflow':
+  elif normalized_system == 'ideaflow':
     user = settings.get('IDEAFLOW_USER')
-  elif note_taking_system == 'remnote':
+  elif normalized_system == 'remnote':
     user = settings.get('REMNOTE_USER_ID')[:6]
-  elif note_taking_system == 'roam':
+  elif normalized_system == 'roam' or normalized_system == 'roam research':
     user = f'{settings.get("ROAM_GRAPH")} {settings.get("ROAM_USER")}'
-  elif note_taking_system == 'mem':
+  elif normalized_system == 'mem':
     user = settings.get('MEM_API_KEY')[:6]
-  elif note_taking_system == 'notion':
+  elif normalized_system == 'notion':
     user = settings.get('NOTION_DATABASE_ID')[:6]
-  elif note_taking_system == 'twitter':
+  elif normalized_system == 'twitter':
     user = settings.get('twitter.screen_name')
+  elif normalized_system == 'dropbox':
+    user = settings.get('DROPBOX_ACCESS_TOKEN')[:6] if settings.get('DROPBOX_ACCESS_TOKEN') else 'unknown'
   say(f'uploader {note_taking_system} ; user {user}')
 
 

--- a/gonotego/settings-server/src/App.tsx
+++ b/gonotego/settings-server/src/App.tsx
@@ -203,20 +203,20 @@ const SettingsUI = () => {
   };
 
   const shouldShowSection = (section) => {
-    const system = settings.NOTE_TAKING_SYSTEM;
+    const system = settings.NOTE_TAKING_SYSTEM?.toLowerCase();
     switch (section) {
       case 'roam':
-        return system === 'Roam Research';
+        return system === 'roam research' || system === 'roam';
       case 'remnote':
-        return system === 'RemNote';
+        return system === 'remnote';
       case 'ideaflow':
-        return system === 'IdeaFlow';
+        return system === 'ideaflow';
       case 'mem':
-        return system === 'Mem';
+        return system === 'mem';
       case 'notion':
-        return system === 'Notion';
+        return system === 'notion';
       case 'twitter':
-        return system === 'Twitter';
+        return system === 'twitter';
       default:
         return true;
     }

--- a/gonotego/uploader/blob/blob_uploader.py
+++ b/gonotego/uploader/blob/blob_uploader.py
@@ -6,7 +6,9 @@ from gonotego.settings import settings
 
 
 def make_client():
-  if settings.get('BLOB_STORAGE_SYSTEM') == 'dropbox':
+  # Handle case sensitivity for blob storage system
+  blob_system = settings.get('BLOB_STORAGE_SYSTEM').lower() if settings.get('BLOB_STORAGE_SYSTEM') else ''
+  if blob_system == 'dropbox':
     return dropbox.Dropbox(settings.get('DROPBOX_ACCESS_TOKEN'))
 
 

--- a/gonotego/uploader/runner.py
+++ b/gonotego/uploader/runner.py
@@ -29,20 +29,27 @@ def is_unconfigured(note_taking_system):
 
 
 def make_uploader(note_taking_system):
-  if note_taking_system == 'email':
+  # Normalize the input to handle both formats (e.g., "Roam Research" and "roam")
+  normalized_system = note_taking_system.lower()
+  
+  if normalized_system == 'email':
     return email_uploader.Uploader()
-  elif note_taking_system == 'ideaflow':
+  elif normalized_system == 'ideaflow':
     return ideaflow_uploader.Uploader()
-  elif note_taking_system == 'remnote':
+  elif normalized_system == 'remnote':
     return remnote_uploader.Uploader()
-  elif note_taking_system == 'roam':
+  elif normalized_system == 'roam' or normalized_system == 'roam research':
     return roam_uploader.Uploader()
-  elif note_taking_system == 'mem':
+  elif normalized_system == 'mem':
     return mem_uploader.Uploader()
-  elif note_taking_system == 'notion':
+  elif normalized_system == 'notion':
     return notion_uploader.Uploader()
-  elif note_taking_system == 'twitter':
+  elif normalized_system == 'twitter':
     return twitter_uploader.Uploader()
+  elif normalized_system == 'dropbox':
+    # Handle Dropbox case sensitivity
+    from gonotego.uploader.blob import blob_uploader
+    return blob_uploader.Uploader()
   else:
     raise ValueError('Unexpected NOTE_TAKING_SYSTEM in settings', note_taking_system)
 


### PR DESCRIPTION
## Summary
- Fix case sensitivity issues with NOTE_TAKING_SYSTEM setting to handle both formats (e.g., "Roam Research" vs "roam", "Dropbox" vs "dropbox")
- Ensures the settings server UI and backend are consistent in how they handle system identifiers

## Original task
the key for Roam Research for the NOTE_TAKING_SYSTEM is roam, not 'Roam Research' -- current the settings server is setting Roam Research instead / looking for that and not showing the right thing when it finds 'roam' instead; pls fix. same for Dropbox vs dropbox etc.

🤖 Generated with [Claude Code](https://claude.ai/code)