### PR TITLE
Fix Wi-Fi network configuration in settings server and improve UI

### DIFF
--- a/gonotego/settings/server.py
+++ b/gonotego/settings/server.py
@@ -175,8 +175,7 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
           try:
             # Handle WiFi networks specially
             if key == 'WIFI_NETWORKS':
-              networks = json.loads(value)
-              wifi.save_networks(networks)
+              wifi.save_networks(value)
               wifi.update_wpa_supplicant_config()
               wifi.reconfigure_wifi()
             else:

--- a/gonotego/settings/server.py
+++ b/gonotego/settings/server.py
@@ -155,11 +155,6 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
   def do_POST(self):
     """Handle POST requests."""
     parsed_path = urlparse(self.path)
-
-    # Early debug log to see if we're getting to this point
-    with open('/tmp/wifi_debug_start.log', 'a') as f:
-      f.write(f"POST request received to {parsed_path.path}\n")
-
     if parsed_path.path == "/api/settings":
       try:
         # Read the request body
@@ -167,13 +162,6 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
         post_data = self.rfile.read(content_length).decode("utf-8")
         settings_data = json.loads(post_data)
 
-        # Write all settings being processed to debug file
-        with open('/tmp/wifi_debug.log', 'a') as f:
-          f.write("===== SETTINGS UPDATE =====\n")
-          for k, v in settings_data.items():
-            f.write(f"Key: {k}, Value type: {type(v)}, Value: {v}\n")
-          f.write("========================\n")
-            
         # Update settings
         for key, value in settings_data.items():
           # Skip masked values - we don't want to overwrite with placeholder text
@@ -189,9 +177,6 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
             # If we're updating WiFi networks, save networks and update the wpa_supplicant.conf file
             if key == 'WIFI_NETWORKS':
               try:
-                # Write debug info to a file that can be checked later
-                with open('/tmp/wifi_debug.log', 'a') as f:
-                  f.write(f"WIFI_NETWORKS value type: {type(value)}, value: {value}\n")
                 # Parse the value to ensure it's in the correct format
                 if isinstance(value, str):
                   networks = json.loads(value)

--- a/gonotego/settings/server.py
+++ b/gonotego/settings/server.py
@@ -156,6 +156,13 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
     """Handle POST requests."""
     parsed_path = urlparse(self.path)
 
+    # Early debug log to see if we're getting to this point
+    try:
+      with open('/tmp/wifi_debug_start.log', 'a') as f:
+        f.write(f"POST request received to {parsed_path.path}\n")
+    except Exception as e:
+      print(f"Error writing to start debug log: {e}")
+
     if parsed_path.path == "/api/settings":
       try:
         # Read the request body
@@ -164,11 +171,14 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
         settings_data = json.loads(post_data)
 
         # Write all settings being processed to debug file
-        with open('/tmp/wifi_debug.log', 'a') as f:
+        try:
+          with open('/tmp/wifi_debug.log', 'a') as f:
             f.write("===== SETTINGS UPDATE =====\n")
             for k, v in settings_data.items():
-                f.write(f"Key: {k}, Value type: {type(v)}, Value: {v}\n")
+              f.write(f"Key: {k}, Value type: {type(v)}, Value: {v}\n")
             f.write("========================\n")
+        except Exception as e:
+          print(f"Error writing to debug log: {e}")
             
         # Update settings
         for key, value in settings_data.items():
@@ -186,8 +196,11 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
             if key == 'WIFI_NETWORKS':
               try:
                 # Write debug info to a file that can be checked later
-                with open('/tmp/wifi_debug.log', 'a') as f:
+                try:
+                  with open('/tmp/wifi_debug.log', 'a') as f:
                     f.write(f"WIFI_NETWORKS value type: {type(value)}, value: {value}\n")
+                except Exception as e:
+                  print(f"Error writing to wifi debug log: {e}")
                 # Parse the value to ensure it's in the correct format
                 if isinstance(value, str):
                   networks = json.loads(value)

--- a/gonotego/settings/server.py
+++ b/gonotego/settings/server.py
@@ -175,22 +175,10 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
           try:
             # Handle WiFi networks specially
             if key == 'WIFI_NETWORKS':
-              try:
-                # Parse the value to ensure it's in the correct format
-                if isinstance(value, str):
-                  networks = json.loads(value)
-                else:
-                  networks = value
-                
-                # Save networks using the wifi module's function
-                # This already calls settings.set() internally
-                wifi.save_networks(networks)
-                
-                # Update wpa_supplicant configuration using the wifi module
-                wifi.update_wpa_supplicant_config()
-                wifi.reconfigure_wifi()
-              except Exception as e:
-                print(f"Error updating WiFi configuration: {e}")
+              networks = json.loads(value)
+              wifi.save_networks(networks)
+              wifi.update_wpa_supplicant_config()
+              wifi.reconfigure_wifi()
             else:
               # For all other settings, just use settings.set
               settings.set(key, value)

--- a/gonotego/settings/server.py
+++ b/gonotego/settings/server.py
@@ -173,8 +173,7 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
             continue
 
           try:
-            settings.set(key, value)
-            # If we're updating WiFi networks, save networks and update the wpa_supplicant.conf file
+            # Handle WiFi networks specially
             if key == 'WIFI_NETWORKS':
               try:
                 # Parse the value to ensure it's in the correct format
@@ -184,6 +183,7 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
                   networks = value
                 
                 # Save networks using the wifi module's function
+                # This already calls settings.set() internally
                 wifi.save_networks(networks)
                 
                 # Update wpa_supplicant configuration using the wifi module
@@ -191,6 +191,9 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
                 wifi.reconfigure_wifi()
               except Exception as e:
                 print(f"Error updating WiFi configuration: {e}")
+            else:
+              # For all other settings, just use settings.set
+              settings.set(key, value)
           except Exception as e:
             print(f"Error setting {key}: {e}")
 

--- a/gonotego/settings/server.py
+++ b/gonotego/settings/server.py
@@ -157,11 +157,8 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
     parsed_path = urlparse(self.path)
 
     # Early debug log to see if we're getting to this point
-    try:
-      with open('/tmp/wifi_debug_start.log', 'a') as f:
-        f.write(f"POST request received to {parsed_path.path}\n")
-    except Exception as e:
-      print(f"Error writing to start debug log: {e}")
+    with open('/tmp/wifi_debug_start.log', 'a') as f:
+      f.write(f"POST request received to {parsed_path.path}\n")
 
     if parsed_path.path == "/api/settings":
       try:
@@ -171,14 +168,11 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
         settings_data = json.loads(post_data)
 
         # Write all settings being processed to debug file
-        try:
-          with open('/tmp/wifi_debug.log', 'a') as f:
-            f.write("===== SETTINGS UPDATE =====\n")
-            for k, v in settings_data.items():
-              f.write(f"Key: {k}, Value type: {type(v)}, Value: {v}\n")
-            f.write("========================\n")
-        except Exception as e:
-          print(f"Error writing to debug log: {e}")
+        with open('/tmp/wifi_debug.log', 'a') as f:
+          f.write("===== SETTINGS UPDATE =====\n")
+          for k, v in settings_data.items():
+            f.write(f"Key: {k}, Value type: {type(v)}, Value: {v}\n")
+          f.write("========================\n")
             
         # Update settings
         for key, value in settings_data.items():
@@ -196,11 +190,8 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
             if key == 'WIFI_NETWORKS':
               try:
                 # Write debug info to a file that can be checked later
-                try:
-                  with open('/tmp/wifi_debug.log', 'a') as f:
-                    f.write(f"WIFI_NETWORKS value type: {type(value)}, value: {value}\n")
-                except Exception as e:
-                  print(f"Error writing to wifi debug log: {e}")
+                with open('/tmp/wifi_debug.log', 'a') as f:
+                  f.write(f"WIFI_NETWORKS value type: {type(value)}, value: {value}\n")
                 # Parse the value to ensure it's in the correct format
                 if isinstance(value, str):
                   networks = json.loads(value)


### PR DESCRIPTION
## Summary
- Fixed issue in settings server where adding Wi-Fi networks via UI wasn't properly updating wpa_supplicant configuration
- Added explicit wifi.save_networks() call to ensure networks are properly saved and formatted
- Improved UI with unsaved changes indicator and disabled Save button when no changes exist
- Fixed bug where Wi-Fi settings would save to Redis but not update the wpa_supplicant config

## Test plan
- Add a new Wi-Fi network in the settings UI
- Verify the Save button shows an unsaved change indicator
- Click Save and verify the network appears in wpa_supplicant.conf
- Test that the system successfully connects to the newly added network
- Verify Save button is disabled when there are no unsaved changes

When I add a new wifi network in the settings UI, the wpa supplicant doesn't seem to be getting updated; is settings.set the right call? or should we be using wifi.save_networks()?

🤖 Generated with [Claude Code](https://claude.ai/code)