### PR TITLE
Optimize settings save by only sending changed values from the client

### DIFF
--- a/gonotego/settings-server/src/App.tsx
+++ b/gonotego/settings-server/src/App.tsx
@@ -143,12 +143,29 @@ const SettingsUI = () => {
   const handleSave = async () => {
     setSaveStatus('saving');
     try {
+      // Create an object with only the changed settings
+      const changedSettings = {};
+      
+      // Compare each setting with its original value
+      for (const [key, value] of Object.entries(settings)) {
+        // Get the original value
+        const originalValue = originalSettings[key];
+        
+        // Check if this setting has changed using string comparison
+        // This handles all types of settings including arrays (via JSON.stringify)
+        if (JSON.stringify(value) !== JSON.stringify(originalValue)) {
+          changedSettings[key] = value;
+        }
+      }
+      
+      console.log('Sending only changed settings:', changedSettings);
+      
       const response = await fetch('/api/settings', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(settings),
+        body: JSON.stringify(changedSettings),
       });
 
       if (!response.ok) {

--- a/gonotego/settings/server.py
+++ b/gonotego/settings/server.py
@@ -175,12 +175,26 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
           try:
             # Handle WiFi networks specially
             if key == 'WIFI_NETWORKS':
-              wifi.save_networks(value)
-              wifi.update_wpa_supplicant_config()
-              wifi.reconfigure_wifi()
+              # Get current networks before saving the new ones
+              current_networks = wifi.get_networks()
+              
+              # Compare current and new networks
+              if json.dumps(current_networks) != json.dumps(value):
+                # Only save and reconfigure if networks have actually changed
+                wifi.save_networks(value)
+                wifi.update_wpa_supplicant_config()
+                wifi.reconfigure_wifi()
+                print("WiFi networks changed, reconfigured WiFi")
+              else:
+                print("WiFi networks unchanged, skipping reconfiguration")
             else:
-              # For all other settings, just use settings.set
-              settings.set(key, value)
+              # For all other settings, only save if changed
+              current_value = settings.get(key)
+              if str(current_value) != str(value):
+                settings.set(key, value)
+                print(f"Setting {key} changed, saved new value")
+              else:
+                print(f"Setting {key} unchanged, skipping save")
           except Exception as e:
             print(f"Error setting {key}: {e}")
 

--- a/gonotego/settings/server.py
+++ b/gonotego/settings/server.py
@@ -175,26 +175,12 @@ class SettingsCombinedHandler(BaseHTTPRequestHandler):
           try:
             # Handle WiFi networks specially
             if key == 'WIFI_NETWORKS':
-              # Get current networks before saving the new ones
-              current_networks = wifi.get_networks()
-              
-              # Compare current and new networks
-              if json.dumps(current_networks) != json.dumps(value):
-                # Only save and reconfigure if networks have actually changed
-                wifi.save_networks(value)
-                wifi.update_wpa_supplicant_config()
-                wifi.reconfigure_wifi()
-                print("WiFi networks changed, reconfigured WiFi")
-              else:
-                print("WiFi networks unchanged, skipping reconfiguration")
+              wifi.save_networks(value)
+              wifi.update_wpa_supplicant_config()
+              wifi.reconfigure_wifi()
             else:
-              # For all other settings, only save if changed
-              current_value = settings.get(key)
-              if str(current_value) != str(value):
-                settings.set(key, value)
-                print(f"Setting {key} changed, saved new value")
-              else:
-                print(f"Setting {key} unchanged, skipping save")
+              # For all other settings, just use settings.set
+              settings.set(key, value)
           except Exception as e:
             print(f"Error setting {key}: {e}")
 


### PR DESCRIPTION
## Summary
- Only send changed settings from the client to the server
- Add client-side comparison to determine which values have actually changed
- Keep the server-side code simple by processing whatever it receives

## Test plan
- Save settings without changing WiFi networks and verify that WIFI_NETWORKS isn't included in the request payload
- Save settings with changed WiFi networks and verify WIFI_NETWORKS is included in the request payload
- Verify other unchanged settings are not included in request payload

When I click save in the settings UI, the raspberry pi freezes up for several seconds; one hypothesis I had is that its the call to reconfigure_wifi that causes things to hang. lets test this hypothesis by skipping saving any unchanged settings (thereby skipping reconfigure_wifi if the wifi list hasn't changed) so we can see if the hanging happens when I don't change the wifi list and just change a different setting; also, if you have other theories as to what's causing the hanging, let me know

🤖 Generated with [Claude Code](https://claude.ai/code)