### PR TITLE
Update installation and hardware documentation

### DIFF
--- a/hardware.md
+++ b/hardware.md
@@ -10,11 +10,17 @@ Link: https://www.raspberrypi.com/products/raspberry-pi-400-unit/
 
 Details: The Raspberry Pi 400 with US keyboard is recommended. You can purchase from e.g. [PiShop](https://www.pishop.us/product/raspberry-pi-400-complete-kit/).
 
-Cost: ~$70
+It's recommended to order the complete kit which includes:
+- The Raspberry Pi 400 unit ($70)
+- Class 10 microSD Card With Raspbian - 16GB
+- USB-C Power Supply, 5.1V 3.0A, Black, UL Listed
+- Micro-HDMI to HDMI cable for Pi 4, 3ft, Black
+
+Cost: ~$70 (unit only) or ~$91 (complete kit)
 
 #### SD Card
 
-A Class 10 microSD Card - 16GB or larger is recommended.
+A Class 10 microSD Card - 16GB or larger is recommended. (This is included if you purchase the complete Raspberry Pi 400 kit).
 
 Cost: ~$10-15
 
@@ -34,7 +40,7 @@ Cost: $13-30
 
 #### Power Source
 
-A USB-C Power Supply, 5.1V 3.0A for the Raspberry Pi 400.
+A USB-C Power Supply, 5.1V 3.0A for the Raspberry Pi 400. (This is included if you purchase the complete Raspberry Pi 400 kit).
 
 Cost: ~$10
 

--- a/hardware.md
+++ b/hardware.md
@@ -1,94 +1,83 @@
 ## Hardware Guide
 
-Here is some sample hardware you can use to build your own Go Note Go. Costs might exclude taxes and shipping.
+Here is the required hardware you need to build your own Go Note Go:
 
-### Raspberry Pi 400
+### Required Hardware
+
+#### Raspberry Pi 400
 
 Link: https://www.raspberrypi.com/products/raspberry-pi-400-unit/
 
-Details: I use the US keyboard. You can purchase from e.g. [PiShop](https://www.pishop.us/product/raspberry-pi-400-complete-kit/). I recommend ordering the following as a bundle:
- - The Raspberry Pi 400 unit ($70)
- - Class 10 microSD Card With Raspbian - 16GB
- - USB-C Power Supply, 5.1V 3.0A, Black, UL Listed
- - Micro-HDMI to HDMI cable for Pi 4, 3ft, Black
+Details: The Raspberry Pi 400 with US keyboard is recommended. You can purchase from e.g. [PiShop](https://www.pishop.us/product/raspberry-pi-400-complete-kit/).
 
-Cost: $91
+Cost: ~$70
 
-### USB Mic and Speakers
+#### SD Card
 
-Links:
-* Microphone: https://www.adafruit.com/product/3367 ($6)
-* Adafruit Speaker: https://www.adafruit.com/product/3369 ($13)
-* Etsy Speaker: https://www.etsy.com/listing/1056790095/usb-speaker-stick ($30)
+A Class 10 microSD Card - 16GB or larger is recommended.
 
-Cost: $19 - $36
+Cost: ~$10-15
+
+#### USB Microphone
+
+Example: https://www.adafruit.com/product/3367
+
+Cost: ~$6
+
+#### USB Speaker
+
+Options:
+* Adafruit Speaker: https://www.adafruit.com/product/3369 (~$13)
+* Etsy Speaker: https://www.etsy.com/listing/1056790095/usb-speaker-stick (~$30)
+
+Cost: $13-30
+
+#### Power Source
+
+A USB-C Power Supply, 5.1V 3.0A for the Raspberry Pi 400.
+
+Cost: ~$10
+
+Total Cost for Required Hardware: ~$109-131
 
 ---
 
-## Additional Hardware: Take Go Note Go on the Go
+## Optional Hardware
 
-The following parts are optional, but will better allow you to take Go Note Go on the go.
+The following parts are optional but may enhance your experience:
 
-### 10000 mAh battery
+### 10000 mAh Battery (for portable use)
 
 Link: https://www.amazon.com/gp/product/B07JYYRT7T
 
-Notes: There are lots of options for the battery. This one works just fine. Could choose one with more storage for longer battery life if desired, but might get clunky. You also don't strictly _need_ a battery. You can also power Go Note Go directly from your car, laptop, or a standard outlet via USB. So if your use case allows Go Note Go to remain plugged in during use, you can forego the battery.
+Notes: This allows you to use Go Note Go away from a power outlet. You can also power Go Note Go directly from your car, laptop, or a standard outlet via USB if your use case allows Go Note Go to remain plugged in during use.
 
-Cost: $19 (currently $14)
+Cost: ~$14-19
 
 ### Velcro
 
 Link: https://www.amazon.com/gp/product/B08P3MXLLD
 
-Notes: I use this Velcro to mount the keyboard to the passenger side of the car, and to mount the battery to the back of the keyboard. When applying the sticky side to a car dashboard, allow to dry overnight.
+Notes: Useful for mounting the keyboard to different surfaces (e.g., car dashboard) or attaching the battery to the back of the keyboard. When applying the sticky side to a car dashboard, allow to dry overnight.
 
-Cost: $7
+Cost: ~$7
 
 ### USB Cables
 
 Links:
-* 3 ft USB - USB C cable: https://www.amazon.com/gp/product/B089DM4KDW
-* 6 in USB - USB C cable: https://www.amazon.com/gp/product/B012V56D2A
-
-Cost: $13 ($6.99 for 3 ft and $5.99 for 6 in)
-
-### The Beautiful Red Button
-
-Link: https://www.amazon.com/gp/product/B00T6RCGNC
-
-Cost: $9
+* USB to USB-C cable for connecting the Pi to power sources
+* Short cables may be useful for connecting peripherals while minimizing clutter
 
 ---
 
-## Other tools
+## Other Tools for Setup
 
-These tools aren't Go Note Go specific, but will help you in the setup process.
+These tools aren't Go Note Go specific, but may help you in the setup process:
 
-### External monitor and a USB Mouse.
+### External Monitor (temporary, for initial setup)
 
-These will be useful for configuring and debugging Go Note Go, e.g. setting up WiFi and configuring your note-taking system.
+This can be useful for initial debugging, but is not required with the new setup process.
 
-### Wire, Wire Stripper
+### USB Mouse (temporary, for initial setup)
 
-If you use The Beautiful Red Button you'll need wire and wire strippers. For wire I used 18 gauge lamp wire I got from Home Depot.
-
-Possible wire link: https://www.lowes.com/pd/Southwire-25-Ft-18-2-Black-Stranded-Lamp-Cord/5001050863
-
-Wire stripper link: https://www.amazon.com/Mr-Stripper-Stripping-Crimping-Electrical/dp/B086V5M1B4 (I chose this link arbitrarily; I got mine at Home Depot).
-
-Notes: I don't know if this is the best choice for wire; a higher gauge might be better.
-
-### Solder? Soldering iron?
-
-I haven't had to use solder yet, but might need to for hooking up the button.
-
-Hot glue or heat shrink and a heat gun might be nice-to-haves too to ensure solid stable connections.
-
-### Possible other parts for button
-
-These might be useful for connecting the button to the GPIO pins on the Pi:
-https://www.amazon.com/dp/B0774NMT1S
-I don't know. In my experience these were too loose to fit nicely on the GPIO pins.
-
-I'm going to try these next: GenBasic 40 Piece Female to Female Jumper Wires (4 Inch) https://www.amazon.com/dp/B077N58HFK ($5)
+This can be helpful during initial configuration but is not required with the new setup process.

--- a/installation.md
+++ b/installation.md
@@ -1,82 +1,62 @@
 ## Installation Instructions
 
-These instructions assume you're starting from a clean install of Raspbian,
-and that your Raspberry Pi is connected to an external monitor.
-Once you are set up, an external monitor will no longer be necessary.
+These instructions will guide you through setting up Go Note Go on a Raspberry Pi 400.
 
-1.  Clone GoNoteGo
+1. Download the latest image from GitHub Actions artifacts
 
-  ```bash
-mkdir -p /home/pi/code/github/dbieber
-cd /home/pi/code/github/dbieber
-git clone https://github.com/dbieber/GoNoteGo.git
-```
+2. Flash the image onto an SD card
+   
+   Example commands (macOS):
+   ```bash
+   diskutil unmountDisk /dev/disk4
+   sudo dd bs=4M if=/Users/yourusername/Downloads/go-note-go.img of=/dev/rdisk4 conv=fsync status=progress
+   ```
 
-2.  Set up settings
+3. Insert the SD card into the Raspberry Pi 400 and power it on
+   
+   Give it a minute to boot.
 
-  ```bash
-cd /home/pi/code/github/dbieber/GoNoteGo
-cp gonotego/settings/secure_settings_template.py gonotego/settings/secure_settings.py
-nano gonotego/settings/secure_settings.py  # Configure your settings here.
-```
+4. Start the settings server
+   
+   Type the following command and press Enter:
+   ```
+   :server
+   ```
+   
+   This will start a WiFi hotspot called GoNoteGo-Wifi.
 
-It's OK to leave settings that you're not using at their default values.
+5. Connect to the GoNoteGo-Wifi hotspot
+   
+   Connect from another device like a phone or computer.
+   The password is: `swingset`
 
-3. Put Google service key on device
+6. Configure your Go Note Go
+   
+   Navigate to: `192.168.4.1:8000`
+   
+   Here you can configure:
+   - WiFi networks to connect to
+   - Where to upload your notes
+   - Other settings
+   
+   Click Save when finished.
 
-* `mkdir /home/pi/secrets`  # Run on Raspberry Pi.
-* `scp path/to/google_credentials.json pi@192.168.0.106:/home/pi/secrets/`  # Run on primary.
+7. Verify internet connection
+   
+   Run the following command on the Go Note Go:
+   ```
+   :i
+   ```
+   
+   It should respond with 'Yes' indicating it's connected to the internet.
 
-Run `hostname -I` on the Raspberry Pi to determine the IP address to use in the scp command.
+8. Turn off the WiFi hotspot (optional)
+   
+   Run the following command:
+   ```
+   :server stop
+   ```
 
-4. Install dependencies
+9. That's it! Your Go Note Go is ready to use. Happy note-taking!
 
-  ```bash
-sudo apt update
-sudo apt upgrade
-sudo apt install firefox-esr xvfb portaudio19-dev libatlas-base-dev redis-server espeak rustc python3-dev
-
-cd /home/pi/code/github/dbieber/GoNoteGo
-mkdir out
-pip3 install virtualenv
-/home/pi/.local/bin/virtualenv env -p python3
-./env/bin/pip install grpcio -U --no-binary=grpcio
-./env/bin/pip install -e .
-```
-
-5. Start on boot
-
-  ```bash
-sudo nano /etc/rc.local
-```
-  Add this line to rc.local:
-  `/home/pi/code/github/dbieber/GoNoteGo/env/bin/supervisord -c /home/pi/code/github/dbieber/GoNoteGo/gonotego/supervisord.conf`
-
-6. Install geckodriver to /usr/local/bin
-
-  ```bash
-cd
-wget https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-arm7hf.tar.gz
-tar -xvf geckodriver-v0.23.0-arm7hf.tar.gz
-rm geckodriver-v0.23.0-arm7hf.tar.gz
-sudo mv geckodriver /usr/local/bin
-```
-
-7. Set up Internet
-
-* Run `sudo nano /etc/wpa_supplicant/wpa_supplicant.conf`
-* Follow the guide at https://www.raspberrypi.org/documentation/computers/configuration.html to set up your wpa_supplicant.conf file.
-
-Setting up internet through the operating system's UI may also work.
-
-8. Set up your audio
-
-* Make sure audio is coming out of the desired output device at an acceptable volume.
-
-9. Verify everything's working!
-
-* Type a text note and press enter; it should appear in your notes.
-* Press your hotkey and speak an audio note; it too should appear in your notes.
-* Type ":ok" and press enter; you should hear the machine say "ok".
-* If you're having any trouble getting set up, open a [new GitHub issue](https://github.com/dbieber/GoNoteGo/issues).
-* That's it; you're good to go! Happy note-taking!
+If you're having any trouble getting set up, open a [new GitHub issue](https://github.com/dbieber/GoNoteGo/issues).

--- a/installation.md
+++ b/installation.md
@@ -48,7 +48,7 @@ These instructions will guide you through setting up Go Note Go on a Raspberry P
    :i
    ```
    
-   It should respond with 'Yes' indicating it's connected to the internet.
+   It should respond out loud with 'Yes' indicating it's connected to the internet.
 
 8. Turn off the WiFi hotspot (optional).
    

--- a/installation.md
+++ b/installation.md
@@ -2,9 +2,9 @@
 
 These instructions will guide you through setting up Go Note Go on a Raspberry Pi 400.
 
-1. Download the latest image from GitHub Actions artifacts
+1. Download the latest image from GitHub Actions artifacts.
 
-2. Flash the image onto an SD card
+2. Flash the image onto an SD card.
    
    Example commands (macOS):
    ```bash
@@ -12,11 +12,11 @@ These instructions will guide you through setting up Go Note Go on a Raspberry P
    sudo dd bs=4M if=/Users/yourusername/Downloads/go-note-go.img of=/dev/rdisk4 conv=fsync status=progress
    ```
 
-3. Insert the SD card into the Raspberry Pi 400 and power it on
+3. Insert the SD card into the Raspberry Pi 400 and power it on.
    
    Give it a minute to boot.
 
-4. Start the settings server
+4. Start the settings server.
    
    Type the following command and press Enter:
    ```
@@ -25,14 +25,14 @@ These instructions will guide you through setting up Go Note Go on a Raspberry P
    
    This will start a WiFi hotspot called GoNoteGo-Wifi.
 
-5. Connect to the GoNoteGo-Wifi hotspot
+5. Connect to the GoNoteGo-Wifi hotspot.
    
    Connect from another device like a phone or computer.
-   The password is: `swingset`
+   The password is: `swingset`.
 
-6. Configure your Go Note Go
+6. Configure your Go Note Go.
    
-   Navigate to: `192.168.4.1:8000`
+   Navigate to: `192.168.4.1:8000`.
    
    Here you can configure:
    - WiFi networks to connect to
@@ -41,7 +41,7 @@ These instructions will guide you through setting up Go Note Go on a Raspberry P
    
    Click Save when finished.
 
-7. Verify internet connection
+7. Verify internet connection.
    
    Run the following command on the Go Note Go:
    ```
@@ -50,7 +50,7 @@ These instructions will guide you through setting up Go Note Go on a Raspberry P
    
    It should respond with 'Yes' indicating it's connected to the internet.
 
-8. Turn off the WiFi hotspot (optional)
+8. Turn off the WiFi hotspot (optional).
    
    Run the following command:
    ```


### PR DESCRIPTION
Update the installation instructions and hardware page -- now the only hardware required is the raspberry pi 400, an sd card, a usb speaker, a usb microphone, and a power source; the rest (the big red button eg) isn't needed. the velcro as always is optional.  the new installation instructions are a bit simpler too: (1) download the latest image from github actions artifacts, (2) flash that image onto an SD card. sample commands: diskutil unmountDisk /dev/disk4; sudo dd bs=4M if=/Users/dbieber/Downloads/go-note-go.img of=/dev/rdisk4 conv=fsync status=progress (3) insert the sd card and start the pi - give it a minute to boot, then run :server (type :server then hit enter) ; that will start a wifi hotspot called GoNoteGo-Wifi. (4) connect to GoNoteGo-Wifi from another device like a phone or computer; the password is "swingset" ; (5) navigate to 192.168.4.1:8000 - there you can configure your Go Note Go. tell it what wifi network(s) to connect to, where to upload your notes, etc. Click save. (6) to make sure its working run :i on the go note go - it should say 'Yes' indicating its connected to the internet (7) to turn off the wifi hotspot, run ":server stop" on the Go Note Go

## Summary
- Updated hardware requirements to only include Pi 400, SD card, mic, speaker, and power
- Simplified installation instructions with new image-based setup process
- Added instructions for WiFi hotspot configuration method

## Test plan
- Verify documentation is clear and accurate
- Test installation steps on a fresh Raspberry Pi 400

🤖 Generated with [Claude Code](https://claude.ai/code)