### PR TITLE
Add SD card link to hardware documentation

### DIFF
--- a/hardware.md
+++ b/hardware.md
@@ -22,6 +22,8 @@ Cost: ~$70 (unit only) or ~$91 (complete kit)
 
 A Class 10 microSD Card - 16GB or larger is recommended. (This is included if you purchase the complete Raspberry Pi 400 kit).
 
+Link: https://www.amazon.com/SanDisk-microSDHC-Memory-Adapter-SDSQUNC-032G-GN6MA/dp/B010Q57T02/
+
 Cost: ~$10-15
 
 #### USB Microphone

--- a/hardware.md
+++ b/hardware.md
@@ -44,6 +44,8 @@ Cost: $13-30
 
 A USB-C Power Supply, 5.1V 3.0A for the Raspberry Pi 400. (This is included if you purchase the complete Raspberry Pi 400 kit).
 
+Link: https://www.raspberrypi.com/products/type-c-power-supply/
+
 Cost: ~$10
 
 Total Cost for Required Hardware: ~$109-131

--- a/hardware.md
+++ b/hardware.md
@@ -75,8 +75,14 @@ Cost: ~$7
 ### USB Cables
 
 Links:
-* USB to USB-C cable for connecting the Pi to power sources
-* Short cables may be useful for connecting peripherals while minimizing clutter
+* 3 ft USB - USB C cable: https://www.amazon.com/gp/product/B089DM4KDW
+* 6 in USB - USB C cable: https://www.amazon.com/gp/product/B012V56D2A
+
+Notes:
+* USB to USB-C cables for connecting the Pi to power sources
+* Short cables are useful for connecting peripherals while minimizing clutter
+
+Cost: ~$13 ($6.99 for 3 ft and $5.99 for 6 in)
 
 ---
 

--- a/hardware.md
+++ b/hardware.md
@@ -82,7 +82,7 @@ Notes:
 * USB to USB-C cables for connecting the Pi to power sources
 * Short cables are useful for connecting peripherals while minimizing clutter
 
-Cost: ~$13 ($6.99 for 3 ft and $5.99 for 6 in)
+Cost: ~$15.50 ($5.99 for 3 ft and $9.49 for 6 in)
 
 ---
 


### PR DESCRIPTION
## Summary
- Re-added the missing link for purchasing a recommended SD card
- Kept the note about SD card being included in the complete Pi 400 kit

## Test plan
- Verify the SD card link works correctly
- Confirm the SD card specs are appropriate for the Go Note Go

🤖 Generated with [Claude Code](https://claude.ai/code)