### PR TITLE
Configure US keyboard layout in build image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,6 +261,8 @@ jobs:
             # Attempt to not run config on first boot
             sudo apt purge piwiz -y
             sudo raspi-config nonint do_wifi_country US
+            # Configure US keyboard layout
+            sudo raspi-config nonint do_configure_keyboard us
             touch /boot/ssh
             echo "pi:$(echo 'raspberry' | openssl passwd -6 -stdin)" | sudo tee /boot/userconf > /dev/null
 


### PR DESCRIPTION
when building the image in .github/workflows/build.yml ensure the resulting image is configured to use a US keyboard layout

🤖 Generated with [Claude Code](https://claude.ai/code)