### PR TITLE
Add essential NetworkManager nmcli commands to bash_history template

### DIFF
--- a/.github/templates/bash_history
+++ b/.github/templates/bash_history
@@ -18,10 +18,10 @@ cat /etc/dnsmasq.conf
 python -m http.server
 sudo iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE
 sudo iptables -t nat -L
-nmcli radio wifi on  # turn on wifi adapter
-nmcli device wifi list  # list available wifi networks
-nmcli -t -f SSID,SIGNAL,SECURITY device wifi list  # show networks with signal strength
-nmcli connection show  # list all network connections
+nmcli radio wifi on
+nmcli device wifi list
+nmcli -t -f SSID,SIGNAL,SECURITY device wifi list
+nmcli connection show
 nmcli connection up id "SSID"  # connect to saved network
 nmcli device wifi connect "SSID" password "PASSWORD"  # connect to new network
 nmcli connection modify "SSID" wifi-sec.psk "NEWPASSWORD"  # change wifi password

--- a/.github/templates/bash_history
+++ b/.github/templates/bash_history
@@ -18,6 +18,18 @@ cat /etc/dnsmasq.conf
 python -m http.server
 sudo iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE
 sudo iptables -t nat -L
+
+# NetworkManager Wi-Fi commands
+nmcli radio wifi on # turn on wifi adapter
+nmcli device wifi list # list available wifi networks
+nmcli -t -f SSID,SIGNAL,SECURITY device wifi list # show networks with signal strength
+nmcli connection show # list all network connections
+nmcli connection up id "SSID" # connect to saved network
+nmcli device wifi connect "SSID" password "PASSWORD" # connect to new network
+nmcli connection modify "SSID" wifi-sec.psk "NEWPASSWORD" # change wifi password
+nmcli connection delete "SSID" # remove connection
+sudo systemctl restart NetworkManager # restart network service
+
 sudo cat /etc/wpa_supplicant/wpa_supplicant.conf
 sudo nano /etc/wpa_supplicant/wpa_supplicant.conf
 nano /home/pi/code/github/dbieber/GoNoteGo/gonotego/settings/secure_settings.py

--- a/.github/templates/bash_history
+++ b/.github/templates/bash_history
@@ -18,18 +18,15 @@ cat /etc/dnsmasq.conf
 python -m http.server
 sudo iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE
 sudo iptables -t nat -L
-
-# NetworkManager Wi-Fi commands
-nmcli radio wifi on # turn on wifi adapter
-nmcli device wifi list # list available wifi networks
-nmcli -t -f SSID,SIGNAL,SECURITY device wifi list # show networks with signal strength
-nmcli connection show # list all network connections
-nmcli connection up id "SSID" # connect to saved network
-nmcli device wifi connect "SSID" password "PASSWORD" # connect to new network
-nmcli connection modify "SSID" wifi-sec.psk "NEWPASSWORD" # change wifi password
-nmcli connection delete "SSID" # remove connection
-sudo systemctl restart NetworkManager # restart network service
-
+nmcli radio wifi on  # turn on wifi adapter
+nmcli device wifi list  # list available wifi networks
+nmcli -t -f SSID,SIGNAL,SECURITY device wifi list  # show networks with signal strength
+nmcli connection show  # list all network connections
+nmcli connection up id "SSID"  # connect to saved network
+nmcli device wifi connect "SSID" password "PASSWORD"  # connect to new network
+nmcli connection modify "SSID" wifi-sec.psk "NEWPASSWORD"  # change wifi password
+nmcli connection delete "SSID"  # remove connection
+sudo systemctl restart NetworkManager  # restart network service
 sudo cat /etc/wpa_supplicant/wpa_supplicant.conf
 sudo nano /etc/wpa_supplicant/wpa_supplicant.conf
 nano /home/pi/code/github/dbieber/GoNoteGo/gonotego/settings/secure_settings.py


### PR DESCRIPTION
## Summary
- Added common NetworkManager nmcli commands to bash_history template with brief descriptive comments
- Placed them logically after iptables commands to maintain grouping of network-related operations
- Included the most useful nmcli commands for connecting to WiFi, managing connections, and troubleshooting

## Original Task
Add to .github/templates/bash_history any critical nmcli commands the user might want to run. put them in a logical place like after the iptables commands. for the least common commands, add 3-6 word comments on the same line as the command, in plain english saying what they do

🤖 Generated with [Claude Code](https://claude.ai/code)