### PR TITLE
Fix issue with Roam uploader marking notes as uploaded when login fails

### DIFF
--- a/gonotego/uploader/email/email_uploader.py
+++ b/gonotego/uploader/email/email_uploader.py
@@ -37,6 +37,7 @@ class Uploader:
         with open(DRAFT_FILENAME, 'a') as f:
           f.write(line + '\n')
         self.last_indent_level = self.indent_level
+    return True
 
   def handle_inactivity(self):
     self.end_session()

--- a/gonotego/uploader/ideaflow/ideaflow_uploader.py
+++ b/gonotego/uploader/ideaflow/ideaflow_uploader.py
@@ -105,6 +105,7 @@ class Uploader:
           audio_url = blob_uploader.upload_blob(note_event.audio_filepath, client)
           text = f'{text} #unverified-transcription ({audio_url})'
         browser.insert_note(text)
+    return True
 
   def handle_inactivity(self):
     self.close_browser()

--- a/gonotego/uploader/mem/mem_uploader.py
+++ b/gonotego/uploader/mem/mem_uploader.py
@@ -34,6 +34,7 @@ class Uploader:
         else:
           is_read = True
         upload_mem(text, is_read=is_read)
+    return True
 
   def handle_inactivity(self):
     pass

--- a/gonotego/uploader/notion/notion_uploader.py
+++ b/gonotego/uploader/notion/notion_uploader.py
@@ -84,6 +84,7 @@ class Uploader:
           url = blob_uploader.upload_blob(note_event.audio_filepath, client)
           blocks.append(make_audio_block(url))
     append_notes(blocks, page_id=self.current_page_id)
+    return True
 
   def handle_inactivity(self):
     self.current_page_id = None

--- a/gonotego/uploader/remnote/remnote_uploader.py
+++ b/gonotego/uploader/remnote/remnote_uploader.py
@@ -42,6 +42,7 @@ class Uploader:
         if note_event.audio_filepath and os.path.exists(note_event.audio_filepath):
           url = blob_uploader.upload_blob(note_event.audio_filepath, client)
           create_rem(url, edit_later=False, parent_id=rem_id)
+    return True
 
   def handle_inactivity(self):
     pass

--- a/gonotego/uploader/roam/roam_uploader.py
+++ b/gonotego/uploader/roam/roam_uploader.py
@@ -200,7 +200,11 @@ class Uploader:
 
   def upload(self, note_events):
     browser = self.get_browser()
-    browser.go_graph(settings.get('ROAM_GRAPH'))
+    if not browser.go_graph(settings.get('ROAM_GRAPH')):
+      # Failed to go to graph - return False to indicate failure
+      print("Failed to access Roam graph. Will retry notes later.")
+      return False
+      
     time.sleep(0.5)
     browser.screenshot('screenshot-graph-later.png')
     browser.execute_helper_js()
@@ -246,6 +250,8 @@ class Uploader:
             browser.create_child_block(block_uid, embed_text)
 
       flush()
+    
+    return True
 
   def handle_inactivity(self):
     self.end_session()

--- a/gonotego/uploader/roam/roam_uploader.py
+++ b/gonotego/uploader/roam/roam_uploader.py
@@ -200,9 +200,11 @@ class Uploader:
 
   def upload(self, note_events):
     browser = self.get_browser()
-    if not browser.go_graph(settings.get('ROAM_GRAPH')):
-      # Failed to go to graph - return False to indicate failure
-      print("Failed to access Roam graph. Will retry notes later.")
+    in_graph = browser.go_graph(settings.get('ROAM_GRAPH'))
+    if not in_graph
+      print("Failed to access Roam graph. Aborting upload.")
+      browser.screenshot('screenshot-go_graph-failure.png')
+      flush()
       return False
       
     time.sleep(0.5)
@@ -240,6 +242,11 @@ class Uploader:
         else:
           parent_uid = self.session_uid
         block_uid = browser.create_child_block(parent_uid, text)
+        if not block_uid:
+          print('create_child_block did not yield a block_uid. Aborting upload.')
+          browser.screenshot('screenshot-create_child_block-failure.png')
+          flush()
+          return False
         self.last_note_uid = block_uid
         print(f'Inserted: "{text}" at block (({block_uid}))')
         if has_audio:

--- a/gonotego/uploader/roam/roam_uploader.py
+++ b/gonotego/uploader/roam/roam_uploader.py
@@ -201,7 +201,7 @@ class Uploader:
   def upload(self, note_events):
     browser = self.get_browser()
     in_graph = browser.go_graph(settings.get('ROAM_GRAPH'))
-    if not in_graph
+    if not in_graph:
       print("Failed to access Roam graph. Aborting upload.")
       browser.screenshot('screenshot-go_graph-failure.png')
       flush()

--- a/gonotego/uploader/runner.py
+++ b/gonotego/uploader/runner.py
@@ -94,13 +94,25 @@ def main():
       status.set(Status.UPLOADER_ACTIVE, True)
       # TODO(dbieber): Allow uploader to yield note events as it finishes them.
       # So that if it fails midway, we can still mark the completed events as done.
-      uploader.upload(note_events)
-      last_upload = time.time()
-      print('Uploaded.')
+      try:
+        upload_success = uploader.upload(note_events)
+        # For older uploaders that don't return a value, assume success
+        if upload_success is None:
+          upload_success = True
+      except Exception as e:
+        print(f"Error during upload: {e}")
+        upload_success = False
+      
+      if upload_success:
+        last_upload = time.time()
+        print('Uploaded.')
+        # Only commit note events if upload was successful
+        for note_event_bytes in note_event_bytes_list:
+          note_events_queue.commit(note_event_bytes)
+      else:
+        print('Upload failed. Will retry notes later.')
+        
       status.set(Status.UPLOADER_ACTIVE, False)
-
-    for note_event_bytes in note_event_bytes_list:
-      note_events_queue.commit(note_event_bytes)
 
     if last_upload and time.time() - last_upload > 600:
       # X minutes have passed since the last upload.


### PR DESCRIPTION
## Summary
- Fix issue where notes are incorrectly marked as uploaded when Roam login fails
- When 'Failed to go to graph. No retries left.' occurs, notes are now kept in the queue for retry instead of being marked as uploaded
- Added explicit success/failure status to the Roam uploader
- Modified the runner to check upload status and only mark notes as committed if upload was successful

## Original Task
in the roam uploader, sometimes it fails to log in (that's fine - we'll sort that out later). we get 'Failed to go to graph. No retries left.'. when this happens, however, it still tries to insert the note into the graph (which of course fails), and the note gets marked as having been uploaded, so we lose the note. instead, when it fails, it should backoff and retry later.

🤖 Generated with [Claude Code](https://claude.ai/code)