### PR TITLE
Fix red CI: pin ruff rule set to the classic default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,14 @@ test = [
 
 [tool.ruff]
 line-length = 180
-lint.ignore = ["E722"]
 exclude = ["scratch"]
+
+[tool.ruff.lint]
+# Pin the rule set to the classic ruff default (pyflakes + pycodestyle
+# errors) so `ruff check` stays deterministic as new ruff versions widen
+# their defaults. E722 (bare except) is used intentionally in a few places.
+select = ["E4", "E7", "E9", "F"]
+ignore = ["E722"]
 
 [build-system]
 requires = ["setuptools>=43.0.0", "wheel"]


### PR DESCRIPTION
## Problem

Every CI run on `main` today is red at the **Lint with ruff** step. Last green build: 2026-07-17 (9ae7fb3). No code change is responsible.

## Cause

The workflow installs `ruff` unpinned (`uv pip install .[test]`, where `test = ['ruff', 'pytest']`) and runs `ruff check .`. `[tool.ruff]` set no explicit `select`, so it relied on ruff's default rule set. A ruff version released after 2026-07-17 widened that default (e.g. import-order `I001`), so previously-passing, untouched files (`gonotego/audio/runner.py` and others) now fail.

## Fix

Pin the rule set explicitly to the classic default the code was written against — `E4`, `E7`, `E9`, `F` — keeping the existing intentional `E722` ignore. Deterministic across ruff versions. **No source files changed.**

## Verified

`ruff check .` clean and `pytest` 64 passed on ruff 0.16.6 (the version CI currently installs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)